### PR TITLE
Typo in README.md 'useing' -> 'using'

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Output: *string* - html output from showdown
 
 `$showdown.stripHtml` - Strips a text of it's HTML tags. See http://stackoverflow.com/questions/17289448/angularjs-to-output-plain-text-instead-of-html
 
-Input: *string* - html to be striped
+Input: *string* - html to be stripped
 
 Output: *string* - string without `<html>` tags
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Output: *string* - stripped html
 
 ## Configuration
 
-You can configure the options and extensions passed to showdown by useing the `$showdownProvider`. To see these options, visit the [Showdown page](https://github.com/showdownjs/showdown).
+You can configure the options and extensions passed to showdown by using the `$showdownProvider`. To see these options, visit the [Showdown page](https://github.com/showdownjs/showdown).
 
 `$showdownProvider.setOption(key, value)` - sets the passed in option as a configuration option in showdown
 


### PR DESCRIPTION
Fixed a minor typo.